### PR TITLE
feat(gnovalidator): add peer-based moniker discovery as fallback source

### DIFF
--- a/backend/internal/gnovalidator/gnovalidator_realtime.go
+++ b/backend/internal/gnovalidator/gnovalidator_realtime.go
@@ -331,7 +331,7 @@ func CollectParticipation(ctx context.Context, db *gorm.DB, chainID string, clie
 	}()
 }
 
-func WatchNewValidators(ctx context.Context, db *gorm.DB, chainID string, client gnoclient.Client, rpcEndpoint string, refreshInterval time.Duration) {
+func WatchNewValidators(ctx context.Context, db *gorm.DB, chainID string, client gnoclient.Client, chainCfg *internal.ChainConfig, refreshInterval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(refreshInterval)
 		defer ticker.Stop()
@@ -346,7 +346,7 @@ func WatchNewValidators(ctx context.Context, db *gorm.DB, chainID string, client
 				oldMap := GetMonikerMap(chainID)
 
 				// Refresh MonikerMap
-				InitMonikerMap(db, chainID, client, rpcEndpoint)
+				InitMonikerMap(db, chainID, client, chainCfg)
 
 				// Compare with the old Monikermap
 				for addr, moniker := range GetMonikerMap(chainID) {
@@ -678,8 +678,8 @@ func StartValidatorMonitoring(ctx context.Context, db *gorm.DB, chainID string, 
 	client := gnoclient.Client{RPCClient: rpcClient}
 
 	t := GetThresholds()
-	InitMonikerMap(db, chainID, client, chainCfg.RPCEndpoint())
-	WatchNewValidators(ctx, db, chainID, client, chainCfg.RPCEndpoint(), t.NewValidatorScan())
+	InitMonikerMap(db, chainID, client, chainCfg)
+	WatchNewValidators(ctx, db, chainID, client, chainCfg, t.NewValidatorScan())
 	CollectParticipation(ctx, db, chainID, client)
 	WatchValidatorAlerts(ctx, db, chainID, t.AlertCheckInterval())
 }

--- a/backend/internal/gnovalidator/valoper.go
+++ b/backend/internal/gnovalidator/valoper.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	"github.com/samouraiworld/gnomonitoring/backend/internal"
 	"github.com/samouraiworld/gnomonitoring/backend/internal/database"
 	"gorm.io/gorm"
 )
@@ -112,7 +116,142 @@ func GetGenesisMonikers(rpcURL string) (map[string]string, error) {
 	return monikers, nil
 }
 
-func InitMonikerMap(db *gorm.DB, chainID string, client gnoclient.Client, rpcEndpoint string) {
+// fetchMonikerFromStatus calls /status on rpcURL and returns the node's
+// consensus validator address and moniker. Returns an error if the RPC is
+// unreachable or the response is incomplete.
+func fetchMonikerFromStatus(rpcURL string) (addr, moniker string, err error) {
+	c, err := rpcclient.NewHTTPClient(rpcURL)
+	if err != nil {
+		return "", "", fmt.Errorf("NewHTTPClient: %w", err)
+	}
+	result, err := c.Status()
+	if err != nil || result == nil {
+		return "", "", fmt.Errorf("Status(): %w", err)
+	}
+	addr = result.ValidatorInfo.Address.String()
+	moniker = result.NodeInfo.Moniker
+	if addr == "" || moniker == "" {
+		return "", "", fmt.Errorf("incomplete status response: addr=%q moniker=%q", addr, moniker)
+	}
+	return addr, moniker, nil
+}
+
+// extractPort returns the port from rawURL, or "26657" if none is present
+// (e.g. the configured RPC is behind a reverse proxy on 443/80).
+func extractPort(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Port() == "" {
+		return "26657"
+	}
+	return u.Port()
+}
+
+// peerDialTimeout bounds the TCP reachability pre-check in
+// discoverMonikersFromPeers, since gno's RPC client does not enforce its own
+// request timeout during the TCP-connect phase (see isPeerReachable).
+const peerDialTimeout = 2 * time.Second
+
+// isPeerReachable reports whether a TCP connection to host:port can be
+// established within timeout. gno's RPC client does not bound the
+// TCP-connect phase with its request timeout, so a peer whose RPC port is
+// firewalled (SYN dropped) can otherwise block for the OS TCP connect
+// timeout (~127s on Linux defaults) before fetchMonikerFromStatus fails.
+func isPeerReachable(host, port string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// isResolvedMoniker reports whether m is a real moniker, as opposed to the
+// "unknown" placeholder persisted by InitMonikerMap for validators that no
+// source could resolve yet.
+func isResolvedMoniker(m string) bool {
+	return m != "" && m != "unknown"
+}
+
+// discoverMonikersFromPeers queries /net_info on each rpcEndpoint, then calls
+// /status on every distinct connected peer to learn its validator address and
+// moniker. Newly discovered pairs are persisted to the addr_monikers table and
+// returned in the result map. Addresses already resolved in existingMonikers
+// (i.e. present with a value other than "" or "unknown") are skipped,
+// preserving DB admin overrides and other moniker sources; addresses still
+// marked "unknown" are retried on every call.
+func discoverMonikersFromPeers(db *gorm.DB, chainID string, rpcEndpoints []string, existingMonikers map[string]string) map[string]string {
+	discovered := make(map[string]string)
+	seenIPs := make(map[string]bool)
+
+	for _, endpoint := range rpcEndpoints {
+		port := extractPort(endpoint)
+
+		c, err := rpcclient.NewHTTPClient(endpoint)
+		if err != nil {
+			log.Printf("[valoper][%s] discovery: NewHTTPClient(%s): %v", chainID, endpoint, err)
+			continue
+		}
+
+		netInfo, err := c.NetInfo()
+		if err != nil || netInfo == nil {
+			log.Printf("[valoper][%s] discovery: NetInfo(%s): %v", chainID, endpoint, err)
+			continue
+		}
+
+		for _, peer := range netInfo.Peers {
+			if peer.RemoteIP == "" || seenIPs[peer.RemoteIP] {
+				continue
+			}
+			seenIPs[peer.RemoteIP] = true
+
+			if !isPeerReachable(peer.RemoteIP, port, peerDialTimeout) {
+				continue
+			}
+
+			peerRPC := fmt.Sprintf("http://%s:%s", peer.RemoteIP, port)
+			addr, moniker, err := fetchMonikerFromStatus(peerRPC)
+			if err != nil {
+				log.Printf("[valoper][%s] discovery: fetchMonikerFromStatus(%s): %v", chainID, peerRPC, err)
+				continue
+			}
+
+			if isResolvedMoniker(existingMonikers[addr]) || isResolvedMoniker(discovered[addr]) {
+				continue
+			}
+
+			discovered[addr] = moniker
+			if err := database.UpsertAddrMoniker(db, chainID, addr, moniker); err != nil {
+				log.Printf("[valoper][%s] discovery: failed to upsert moniker for %s: %v", chainID, addr, err)
+			}
+		}
+	}
+
+	return discovered
+}
+
+// resolveMoniker picks the display moniker for addr using the documented
+// priority order: DB override > valoper realm > genesis file > peer
+// discovery (last resort) > "unknown". A "unknown" placeholder in dbMap
+// (persisted by a previous run) is treated as not-yet-resolved, so a
+// validator can still pick up a name from valoper, genesis or peer discovery
+// once one becomes available.
+func resolveMoniker(addr string, dbMap, valoperMap, genesisMap, discoveredMap map[string]string) string {
+	if m, ok := dbMap[addr]; ok && isResolvedMoniker(m) {
+		return m
+	}
+	if m, ok := valoperMap[addr]; ok {
+		return m
+	}
+	if m, ok := genesisMap[addr]; ok {
+		return m
+	}
+	if m, ok := discoveredMap[addr]; ok {
+		return m
+	}
+	return "unknown"
+}
+
+func InitMonikerMap(db *gorm.DB, chainID string, client gnoclient.Client, chainCfg *internal.ChainConfig) {
 	type Validator struct {
 		Address string `json:"address"`
 	}
@@ -122,7 +261,7 @@ func InitMonikerMap(db *gorm.DB, chainID string, client gnoclient.Client, rpcEnd
 		} `json:"result"`
 	}
 	// Step 1 — Retrieve active validators from the RPC endpoint `/validators`
-	url := fmt.Sprintf("%s/validators", strings.TrimRight(rpcEndpoint, "/"))
+	url := fmt.Sprintf("%s/validators", strings.TrimRight(chainCfg.RPCEndpoint(), "/"))
 	var resp *http.Response
 	err := doWithRetry(3, 2*time.Second, func() error {
 		var e error
@@ -167,7 +306,7 @@ func InitMonikerMap(db *gorm.DB, chainID string, client gnoclient.Client, rpcEnd
 	}
 
 	// Step 3 — Genesis monikers
-	genesisMap, err := GetGenesisMonikers(rpcEndpoint)
+	genesisMap, err := GetGenesisMonikers(chainCfg.RPCEndpoint())
 	if err != nil {
 		log.Printf("⚠️ Failed to get genesis monikers: %v", err)
 	}
@@ -176,22 +315,21 @@ func InitMonikerMap(db *gorm.DB, chainID string, client gnoclient.Client, rpcEnd
 	if err != nil {
 		log.Printf("⚠️ Failed to get monikers from DB: %v", err)
 	}
+	if dbMap == nil {
+		dbMap = make(map[string]string)
+	}
+
+	// Step 4.5 — Discover monikers of still-unresolved validators via peer /net_info + /status,
+	// persisting newly found pairs to the addr_monikers table. Used as a last resort in Step 5,
+	// below valoperMap and genesisMap.
+	discoveredMap := discoverMonikersFromPeers(db, chainID, chainCfg.RPCEndpoints, dbMap)
 
 	// Step 5 — Building a Complete and Prioritized MonikerMap
 	tempMonikers := make(map[string]string)
 
 	for _, val := range validatorsResp.Result.Validators {
 		addr := val.Address
-		moniker := "unknown"
-		if m, ok := dbMap[addr]; ok {
-			moniker = m
-		} else if m, ok := valoperMap[addr]; ok {
-			moniker = m
-		} else if m, ok := genesisMap[addr]; ok {
-			moniker = m
-		}
-
-		tempMonikers[addr] = moniker
+		tempMonikers[addr] = resolveMoniker(addr, dbMap, valoperMap, genesisMap, discoveredMap)
 	}
 
 	for addr, moniker := range tempMonikers {

--- a/backend/internal/gnovalidator/valoper_test.go
+++ b/backend/internal/gnovalidator/valoper_test.go
@@ -1,0 +1,478 @@
+package gnovalidator
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	rpctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+	p2pTypes "github.com/gnolang/gno/tm2/pkg/p2p/types"
+	"github.com/samouraiworld/gnomonitoring/backend/internal/database"
+	"github.com/samouraiworld/gnomonitoring/backend/internal/testoutils"
+)
+
+// newMockRPCServer returns an httptest server that dispatches each JSON-RPC
+// request to handlers[req.Method] and replies with the amino-JSON encoding
+// of the returned result. A nil result with ok=false replies with an
+// RPCInternalError, simulating a failing RPC method.
+func newMockRPCServer(t *testing.T, handlers map[string]func() (result any, ok bool)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpctypes.RPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		handler, found := handlers[req.Method]
+		if !found {
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+		var resp rpctypes.RPCResponse
+		if result, ok := handler(); ok {
+			resp = rpctypes.NewRPCSuccessResponse(req.ID, result)
+		} else {
+			resp = rpctypes.RPCInternalError(req.ID, errors.New("mock RPC error"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+}
+
+// singleResult returns a handler that always succeeds with result.
+func singleResult(result any) func() (any, bool) {
+	return func() (any, bool) { return result, true }
+}
+
+func TestExtractPort(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"explicit port", "http://127.0.0.1:26657", "26657"},
+		{"https no port", "https://rpc.betanet.gno.land", "26657"},
+		{"https explicit port", "https://rpc.betanet.gno.land:443", "443"},
+		{"invalid url", "://bad", "26657"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractPort(tc.url)
+			if got != tc.want {
+				t.Errorf("extractPort(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsPeerReachable(t *testing.T) {
+	t.Run("returns true when the TCP port is open", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("net.Listen() error = %v", err)
+		}
+		defer ln.Close()
+
+		host, port, err := net.SplitHostPort(ln.Addr().String())
+		if err != nil {
+			t.Fatalf("SplitHostPort() error = %v", err)
+		}
+
+		if !isPeerReachable(host, port, time.Second) {
+			t.Errorf("isPeerReachable() = false, want true for an open port")
+		}
+	})
+
+	t.Run("returns false when the TCP port is closed", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("net.Listen() error = %v", err)
+		}
+		host, port, err := net.SplitHostPort(ln.Addr().String())
+		if err != nil {
+			t.Fatalf("SplitHostPort() error = %v", err)
+		}
+		ln.Close() // free the port so nothing is listening
+
+		if isPeerReachable(host, port, time.Second) {
+			t.Errorf("isPeerReachable() = true, want false for a closed port")
+		}
+	})
+}
+
+func TestFetchMonikerFromStatus(t *testing.T) {
+	t.Run("returns addr and moniker from a valid /status response", func(t *testing.T) {
+		pubKey := ed25519.GenPrivKey().PubKey()
+		wantAddr := crypto.AddressFromPreimage(pubKey.Bytes()).String()
+
+		status := &ctypes.ResultStatus{
+			NodeInfo: p2pTypes.NodeInfo{Moniker: "alice-node"},
+			ValidatorInfo: ctypes.ValidatorInfo{
+				Address: crypto.AddressFromPreimage(pubKey.Bytes()),
+				PubKey:  pubKey,
+			},
+		}
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"status": singleResult(status),
+		})
+		defer server.Close()
+
+		addr, moniker, err := fetchMonikerFromStatus(server.URL)
+		if err != nil {
+			t.Fatalf("fetchMonikerFromStatus() error = %v", err)
+		}
+		if addr != wantAddr {
+			t.Errorf("addr = %q, want %q", addr, wantAddr)
+		}
+		if moniker != "alice-node" {
+			t.Errorf("moniker = %q, want %q", moniker, "alice-node")
+		}
+	})
+
+	t.Run("returns an error when the RPC is unreachable", func(t *testing.T) {
+		_, _, err := fetchMonikerFromStatus("http://127.0.0.1:0")
+		if err == nil {
+			t.Fatal("expected an error for unreachable RPC, got nil")
+		}
+	})
+
+	t.Run("returns an error when the moniker is empty", func(t *testing.T) {
+		pubKey := ed25519.GenPrivKey().PubKey()
+		status := &ctypes.ResultStatus{
+			NodeInfo: p2pTypes.NodeInfo{Moniker: ""},
+			ValidatorInfo: ctypes.ValidatorInfo{
+				Address: crypto.AddressFromPreimage(pubKey.Bytes()),
+				PubKey:  pubKey,
+			},
+		}
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"status": singleResult(status),
+		})
+		defer server.Close()
+
+		_, _, err := fetchMonikerFromStatus(server.URL)
+		if err == nil {
+			t.Fatal("expected an error for empty moniker, got nil")
+		}
+	})
+}
+
+func TestDiscoverMonikersFromPeers(t *testing.T) {
+	t.Run("discovers and persists a new moniker from a connected peer", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+		pubKey := ed25519.GenPrivKey().PubKey()
+		addr := crypto.AddressFromPreimage(pubKey.Bytes()).String()
+
+		netInfo := &ctypes.ResultNetInfo{
+			Peers: []ctypes.Peer{
+				{RemoteIP: "127.0.0.1", NodeInfo: p2pTypes.NodeInfo{Moniker: "peer-net-info-moniker"}},
+			},
+		}
+		status := &ctypes.ResultStatus{
+			NodeInfo: p2pTypes.NodeInfo{Moniker: "alice-node"},
+			ValidatorInfo: ctypes.ValidatorInfo{
+				Address: crypto.AddressFromPreimage(pubKey.Bytes()),
+				PubKey:  pubKey,
+			},
+		}
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"net_info": singleResult(netInfo),
+			"status":   singleResult(status),
+		})
+		defer server.Close()
+
+		existing := map[string]string{}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{server.URL}, existing)
+
+		if got := discovered[addr]; got != "alice-node" {
+			t.Errorf("discovered[%s] = %q, want %q", addr, got, "alice-node")
+		}
+		dbMap, err := database.GetMoniker(db, testoutils.TestChainID)
+		if err != nil {
+			t.Fatalf("GetMoniker() error = %v", err)
+		}
+		if got := dbMap[addr]; got != "alice-node" {
+			t.Errorf("DB moniker for %s = %q, want %q", addr, got, "alice-node")
+		}
+	})
+
+	t.Run("does not overwrite an existing moniker", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+		pubKey := ed25519.GenPrivKey().PubKey()
+		addr := crypto.AddressFromPreimage(pubKey.Bytes()).String()
+
+		if err := database.UpsertAddrMoniker(db, testoutils.TestChainID, addr, "admin-override"); err != nil {
+			t.Fatalf("seed UpsertAddrMoniker() error = %v", err)
+		}
+
+		netInfo := &ctypes.ResultNetInfo{
+			Peers: []ctypes.Peer{
+				{RemoteIP: "127.0.0.1", NodeInfo: p2pTypes.NodeInfo{Moniker: "peer-net-info-moniker"}},
+			},
+		}
+		status := &ctypes.ResultStatus{
+			NodeInfo: p2pTypes.NodeInfo{Moniker: "alice-node"},
+			ValidatorInfo: ctypes.ValidatorInfo{
+				Address: crypto.AddressFromPreimage(pubKey.Bytes()),
+				PubKey:  pubKey,
+			},
+		}
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"net_info": singleResult(netInfo),
+			"status":   singleResult(status),
+		})
+		defer server.Close()
+
+		existing := map[string]string{addr: "admin-override"}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{server.URL}, existing)
+
+		if _, ok := discovered[addr]; ok {
+			t.Errorf("discovered[%s] = %q, want not present", addr, discovered[addr])
+		}
+		dbMap, err := database.GetMoniker(db, testoutils.TestChainID)
+		if err != nil {
+			t.Fatalf("GetMoniker() error = %v", err)
+		}
+		if got := dbMap[addr]; got != "admin-override" {
+			t.Errorf("DB moniker for %s = %q, want unchanged %q", addr, got, "admin-override")
+		}
+	})
+
+	t.Run("treats a stale 'unknown' placeholder as not-yet-found and retries discovery", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+		pubKey := ed25519.GenPrivKey().PubKey()
+		addr := crypto.AddressFromPreimage(pubKey.Bytes()).String()
+
+		if err := database.UpsertAddrMoniker(db, testoutils.TestChainID, addr, "unknown"); err != nil {
+			t.Fatalf("seed UpsertAddrMoniker() error = %v", err)
+		}
+
+		netInfo := &ctypes.ResultNetInfo{
+			Peers: []ctypes.Peer{
+				{RemoteIP: "127.0.0.1", NodeInfo: p2pTypes.NodeInfo{Moniker: "peer-net-info-moniker"}},
+			},
+		}
+		status := &ctypes.ResultStatus{
+			NodeInfo: p2pTypes.NodeInfo{Moniker: "alice-node"},
+			ValidatorInfo: ctypes.ValidatorInfo{
+				Address: crypto.AddressFromPreimage(pubKey.Bytes()),
+				PubKey:  pubKey,
+			},
+		}
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"net_info": singleResult(netInfo),
+			"status":   singleResult(status),
+		})
+		defer server.Close()
+
+		existing := map[string]string{addr: "unknown"}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{server.URL}, existing)
+
+		if got := discovered[addr]; got != "alice-node" {
+			t.Errorf("discovered[%s] = %q, want %q", addr, got, "alice-node")
+		}
+		dbMap, err := database.GetMoniker(db, testoutils.TestChainID)
+		if err != nil {
+			t.Fatalf("GetMoniker() error = %v", err)
+		}
+		if got := dbMap[addr]; got != "alice-node" {
+			t.Errorf("DB moniker for %s = %q, want %q", addr, got, "alice-node")
+		}
+	})
+
+	t.Run("skips a peer whose /status call fails, without error", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+
+		netInfo := &ctypes.ResultNetInfo{
+			Peers: []ctypes.Peer{
+				{RemoteIP: "127.0.0.1", NodeInfo: p2pTypes.NodeInfo{Moniker: "peer-net-info-moniker"}},
+			},
+		}
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"net_info": singleResult(netInfo),
+			"status":   func() (any, bool) { return nil, false }, // simulate RPC error
+		})
+		defer server.Close()
+
+		existing := map[string]string{}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{server.URL}, existing)
+
+		if len(discovered) != 0 {
+			t.Errorf("discovered = %v, want empty", discovered)
+		}
+		dbMap, err := database.GetMoniker(db, testoutils.TestChainID)
+		if err != nil {
+			t.Fatalf("GetMoniker() error = %v", err)
+		}
+		if len(dbMap) != 0 {
+			t.Errorf("DB monikers = %v, want empty", dbMap)
+		}
+	})
+
+	t.Run("ignores an unreachable rpc endpoint without error", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+
+		existing := map[string]string{}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{"http://127.0.0.1:0"}, existing)
+
+		if len(discovered) != 0 {
+			t.Errorf("discovered = %v, want empty", discovered)
+		}
+	})
+
+	t.Run("skips a peer whose RPC port is unreachable, without calling /status", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+
+		netInfo := &ctypes.ResultNetInfo{
+			Peers: []ctypes.Peer{
+				// 127.0.0.2 has nothing listening on the mock server's port:
+				// httptest.NewServer binds to 127.0.0.1 only.
+				{RemoteIP: "127.0.0.2", NodeInfo: p2pTypes.NodeInfo{Moniker: "ghost-peer"}},
+			},
+		}
+		statusCalls := 0
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"net_info": singleResult(netInfo),
+			"status": func() (any, bool) {
+				statusCalls++
+				return nil, false
+			},
+		})
+		defer server.Close()
+
+		existing := map[string]string{}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{server.URL}, existing)
+
+		if statusCalls != 0 {
+			t.Errorf("/status called %d times, want 0 (unreachable peer should be skipped)", statusCalls)
+		}
+		if len(discovered) != 0 {
+			t.Errorf("discovered = %v, want empty", discovered)
+		}
+	})
+
+	t.Run("dedupes peers sharing the same remote IP and skips peers with empty IP", func(t *testing.T) {
+		db := testoutils.NewTestDB(t)
+		pubKey := ed25519.GenPrivKey().PubKey()
+		addr := crypto.AddressFromPreimage(pubKey.Bytes()).String()
+
+		netInfo := &ctypes.ResultNetInfo{
+			Peers: []ctypes.Peer{
+				{RemoteIP: "", NodeInfo: p2pTypes.NodeInfo{Moniker: "no-ip-peer"}},
+				{RemoteIP: "127.0.0.1", NodeInfo: p2pTypes.NodeInfo{Moniker: "peer-1"}},
+				{RemoteIP: "127.0.0.1", NodeInfo: p2pTypes.NodeInfo{Moniker: "peer-2"}},
+			},
+		}
+		status := &ctypes.ResultStatus{
+			NodeInfo: p2pTypes.NodeInfo{Moniker: "bob-node"},
+			ValidatorInfo: ctypes.ValidatorInfo{
+				Address: crypto.AddressFromPreimage(pubKey.Bytes()),
+				PubKey:  pubKey,
+			},
+		}
+		statusCalls := 0
+		server := newMockRPCServer(t, map[string]func() (any, bool){
+			"net_info": singleResult(netInfo),
+			"status": func() (any, bool) {
+				statusCalls++
+				return status, true
+			},
+		})
+		defer server.Close()
+
+		existing := map[string]string{}
+		discovered := discoverMonikersFromPeers(db, testoutils.TestChainID, []string{server.URL}, existing)
+
+		if statusCalls != 1 {
+			t.Errorf("/status called %d times, want 1 (deduped)", statusCalls)
+		}
+		if got := discovered[addr]; got != "bob-node" {
+			t.Errorf("discovered[%s] = %q, want %q", addr, got, "bob-node")
+		}
+	})
+}
+
+func TestResolveMoniker(t *testing.T) {
+	cases := []struct {
+		name          string
+		dbMap         map[string]string
+		valoperMap    map[string]string
+		genesisMap    map[string]string
+		discoveredMap map[string]string
+		want          string
+	}{
+		{
+			name:          "db override wins over valoper, genesis and discovered",
+			dbMap:         map[string]string{"addr1": "db-name"},
+			valoperMap:    map[string]string{"addr1": "valoper-name"},
+			genesisMap:    map[string]string{"addr1": "genesis-name"},
+			discoveredMap: map[string]string{"addr1": "discovered-name"},
+			want:          "db-name",
+		},
+		{
+			name:          "stale 'unknown' in db falls through to valoper",
+			dbMap:         map[string]string{"addr1": "unknown"},
+			valoperMap:    map[string]string{"addr1": "valoper-name"},
+			genesisMap:    map[string]string{"addr1": "genesis-name"},
+			discoveredMap: map[string]string{"addr1": "discovered-name"},
+			want:          "valoper-name",
+		},
+		{
+			name:          "valoper wins over genesis and discovered",
+			dbMap:         map[string]string{},
+			valoperMap:    map[string]string{"addr1": "valoper-name"},
+			genesisMap:    map[string]string{"addr1": "genesis-name"},
+			discoveredMap: map[string]string{"addr1": "discovered-name"},
+			want:          "valoper-name",
+		},
+		{
+			name:          "genesis wins over discovered",
+			dbMap:         map[string]string{},
+			valoperMap:    map[string]string{},
+			genesisMap:    map[string]string{"addr1": "genesis-name"},
+			discoveredMap: map[string]string{"addr1": "discovered-name"},
+			want:          "genesis-name",
+		},
+		{
+			name:          "discovered is the last resort",
+			dbMap:         map[string]string{},
+			valoperMap:    map[string]string{},
+			genesisMap:    map[string]string{},
+			discoveredMap: map[string]string{"addr1": "discovered-name"},
+			want:          "discovered-name",
+		},
+		{
+			name:          "falls back to unknown when no source has the address",
+			dbMap:         map[string]string{},
+			valoperMap:    map[string]string{},
+			genesisMap:    map[string]string{},
+			discoveredMap: map[string]string{},
+			want:          "unknown",
+		},
+		{
+			name:          "stale 'unknown' in db with no other source resolves to unknown",
+			dbMap:         map[string]string{"addr1": "unknown"},
+			valoperMap:    map[string]string{},
+			genesisMap:    map[string]string{},
+			discoveredMap: map[string]string{},
+			want:          "unknown",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveMoniker("addr1", tc.dbMap, tc.valoperMap, tc.genesisMap, tc.discoveredMap)
+			if got != tc.want {
+				t.Errorf("resolveMoniker() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor InitMonikerMap and WatchNewValidators to take *internal.ChainConfig instead of a single RPC endpoint, giving access to all configured RPCEndpoints. Add discoverMonikersFromPeers, which queries /net_info and /status on connected peers to resolve monikers for validators not found in the DB, valoper registry, or genesis file.

Discovered monikers are used as a last-resort priority tier via the new resolveMoniker helper (DB override > valoper > genesis > peer discovery > unknown). A stale "unknown" placeholder from a previous run no longer blocks re-resolution on subsequent runs.

isPeerReachable bounds the TCP-connect phase to 2s, since gno's RPC client does not enforce its own request timeout during connection setup.