### PR TITLE
fix(api): run CORS before Clerk auth so OPTIONS preflight succeeds

### DIFF
--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -1122,6 +1122,23 @@ func EnableCORS(w http.ResponseWriter, r ...*http.Request) {
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 }
 
+// corsThenAuth runs EnableCORS and short-circuits OPTIONS preflight with
+// 200 OK before the auth middleware runs. This is required because
+// clerkhttp.RequireHeaderAuthorization returns 403 for preflight requests
+// (browsers never send Authorization on OPTIONS), which would otherwise
+// prevent EnableCORS from running and break CORS for the real request.
+func corsThenAuth(next http.Handler, protect func(http.Handler) http.Handler) http.Handler {
+	authed := protect(next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		EnableCORS(w, r)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		authed.ServeHTTP(w, r)
+	})
+}
+
 // ======================== Start API =====================================
 func StartWebhookAPI(db *gorm.DB) {
 	clerk.SetKey(internal.Config.ClerkSecretKey)
@@ -1195,6 +1212,9 @@ func StartWebhookAPI(db *gorm.DB) {
 			UpdateAlertContactHandler(w, r, db)
 		case http.MethodDelete:
 			DeleteAlertContactHandler(w, r, db)
+		case http.MethodOptions:
+			EnableCORS(w, r)
+			w.WriteHeader(http.StatusOK)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -1222,13 +1242,17 @@ func StartWebhookAPI(db *gorm.DB) {
 		mux.Handle("/alert-contacts", alertContactsHandler)
 		mux.Handle("/usersH", usersHHandler)
 	} else {
-		// In production mode, use Clerk protection
+		// In production mode, use Clerk protection.
+		// CORS headers (and OPTIONS preflight short-circuit) must be applied
+		// before the Clerk auth check, since RequireHeaderAuthorization
+		// returns 403 for preflight requests and would otherwise prevent
+		// EnableCORS from ever running.
 		protected := clerkhttp.RequireHeaderAuthorization()
-		mux.Handle("/webhooks/govdao", protected(webhookGovDAOHandler))
-		mux.Handle("/webhooks/validator", protected(webhookValidatorHandler))
-		mux.Handle("/users", protected(userHandler))
-		mux.Handle("/alert-contacts", protected(alertContactsHandler))
-		mux.Handle("/usersH", protected(usersHHandler))
+		mux.Handle("/webhooks/govdao", corsThenAuth(webhookGovDAOHandler, protected))
+		mux.Handle("/webhooks/validator", corsThenAuth(webhookValidatorHandler, protected))
+		mux.Handle("/users", corsThenAuth(userHandler, protected))
+		mux.Handle("/alert-contacts", corsThenAuth(alertContactsHandler, protected))
+		mux.Handle("/usersH", corsThenAuth(usersHHandler, protected))
 	}
 
 	// ====================== Dashboard =================

--- a/backend/internal/api/cors_helper_test.go
+++ b/backend/internal/api/cors_helper_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	clerkhttp "github.com/clerk/clerk-sdk-go/v2/http"
+	"github.com/samouraiworld/gnomonitoring/backend/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+var dummyOKHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+// TestCorsThenAuth_OptionsPreflight_NoAuthHeader reproduces the production bug:
+// a CORS preflight OPTIONS request never carries an Authorization header, so
+// clerkhttp.RequireHeaderAuthorization alone would return 403 with no CORS
+// headers, before the wrapped handler's own OPTIONS branch ever runs.
+func TestCorsThenAuth_OptionsPreflight_NoAuthHeader(t *testing.T) {
+	internal.Config.DevMode = false
+	internal.Config.AllowedOrigins = []string{"https://app.example.com"}
+	defer func() {
+		internal.Config.DevMode = false
+		internal.Config.AllowedOrigins = nil
+	}()
+
+	protected := clerkhttp.RequireHeaderAuthorization()
+	handler := corsThenAuth(dummyOKHandler, protected)
+
+	req := httptest.NewRequest(http.MethodOptions, "/users", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "https://app.example.com", res.Header.Get("Access-Control-Allow-Origin"))
+}
+
+// TestCorsThenAuth_NonOptionsWithoutAuth_StillRejected verifies the fix doesn't
+// bypass auth: a real request without an Authorization header is still
+// rejected by clerkhttp, but the response still carries CORS headers.
+func TestCorsThenAuth_NonOptionsWithoutAuth_StillRejected(t *testing.T) {
+	internal.Config.DevMode = false
+	internal.Config.AllowedOrigins = []string{"https://app.example.com"}
+	defer func() {
+		internal.Config.DevMode = false
+		internal.Config.AllowedOrigins = nil
+	}()
+
+	protected := clerkhttp.RequireHeaderAuthorization()
+	handler := corsThenAuth(dummyOKHandler, protected)
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+	assert.Equal(t, "https://app.example.com", res.Header.Get("Access-Control-Allow-Origin"))
+}


### PR DESCRIPTION
In production, RequireHeaderAuthorization wrapped the whole handler, including its OPTIONS branch. Browsers never send Authorization on preflight requests, so Clerk returned 403 before EnableCORS ever ran, leaving the preflight response without Access-Control-Allow-Origin and causing the browser to block the real request.

Add corsThenAuth to set CORS headers and short-circuit OPTIONS with 200 before the auth middleware runs, mirroring the pattern already used for /admin routes. Also add the missing OPTIONS case to alertContactsHandler.